### PR TITLE
Update dependecies to latest version at 11/25

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "stage": 0
+  "presets": ["es2015", "stage-0", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+  {
   "name": "react-hot-boilerplate",
   "version": "1.0.0",
   "description": "Boilerplate for ReactJS project with hot code reloading",
@@ -28,26 +28,30 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-boilerplate",
   "devDependencies": {
-    "babel-core": "^5.8.3",
-    "babel-eslint": "^4.0.5",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.0.20",
+    "babel-eslint": "^4.1.3",
+    "babel-loader": "^6.0.1",
+    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-react": "^6.0.15",
+    "babel-preset-stage-0": "^6.0.15",
     "css-loader": "^0.15.6",
     "cssnext-loader": "^1.0.1",
-    "eslint": "^0.24.1",
-    "eslint-plugin-react": "^3.1.0",
-    "extract-text-webpack-plugin": "^0.8.2",
+    "eslint": "^1.10.1",
+    "eslint-plugin-react": "^3.6.2",
+    "extract-text-webpack-plugin": "^0.9.1",
     "html-webpack-plugin": "^1.6.1",
-    "react-hot-loader": "^1.2.7",
-    "redux-devtools": "^1.0.2",
+    "react-hot-loader": "^1.3.0",
+    "redux-devtools": "^2.1.5",
     "style-loader": "^0.12.3",
-    "webpack": "^1.9.6",
-    "webpack-dev-server": "^1.8.2"
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
     "classnames": "^2.1.3",
     "lodash": "^3.10.1",
-    "react": "^0.13.0",
-    "react-redux": "^0.2.2",
-    "redux": "^1.0.0-rc"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.4"
   }
 }

--- a/src/components/FriendList.js
+++ b/src/components/FriendList.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import mapValues from 'lodash/object/mapValues';
+import map from 'lodash/collection/map';
 
 import styles from './FriendList.css';
 import FriendListItem from './FriendListItem';
@@ -14,7 +14,7 @@ export default class FriendList extends Component {
     return (
       <ul className={styles.friendList}>
         {
-          mapValues(this.props.friends, (friend) => {
+          map(this.props.friends, (friend) => {
             return (<FriendListItem
               key={friend.id}
               id={friend.id}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -15,10 +15,10 @@ export default class App extends Component {
     return (
       <div>
         <Provider store={store}>
-          {() => <FriendListApp /> }
+          <FriendListApp />
         </Provider>
 
-        {renderDevTools(store)}
+        { renderDevTools(store) }
       </div>
     );
   }

--- a/src/containers/FriendListApp.js
+++ b/src/containers/FriendListApp.js
@@ -6,13 +6,10 @@ import { connect } from 'react-redux';
 import * as FriendsActions from '../actions/FriendsActions';
 import { FriendList, AddFriendInput } from '../components';
 
-@connect(state => ({
-  friendlist: state.friendlist
-}))
-export default class FriendListApp extends Component {
+class FriendListApp extends Component {
 
   static propTypes = {
-    friendsById: PropTypes.object.isRequired,
+    // friendsById: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired
   }
 
@@ -29,3 +26,13 @@ export default class FriendListApp extends Component {
     );
   }
 }
+
+
+// Babel 6.x doesn't seem to support decorators yet
+function select(state) {
+  return {
+    friendlist: state.friendlist
+  }
+}
+
+export default connect(select)(FriendListApp)

--- a/src/store_enhancers/devTools.js
+++ b/src/store_enhancers/devTools.js
@@ -8,9 +8,8 @@ if (__DEV__) {
     require('redux-devtools').devTools(),
     require('redux-devtools').persistState(
       window.location.href.match(/[?&]debug_session=([^&]+)\b/)
-    ),
-    createStore
-  );
+    )
+  )(createStore);
 }
 
 export function renderDevTools(store) {


### PR DESCRIPTION
- Update dependecies, react0.14, redux3.x and babel 6.x
- Change createStore, to stick with redux 2.0+ version
- Change App.js to render the child directly without a wrapper function
- Remove decorator in friendListApp, it doesn't seem to work with babel 6.x
- Few more changes in components to make the app work
